### PR TITLE
Add email notification script

### DIFF
--- a/src/email_utils.py
+++ b/src/email_utils.py
@@ -1,0 +1,28 @@
+import os
+import smtplib
+from email.message import EmailMessage
+
+
+def send_email(
+    recipient: str,
+    *,
+    subject: str = "Script executed",
+    body: str = "The script has been executed.",
+) -> None:
+    """Send a notification email using environment-provided SMTP settings."""
+
+    smtp_server = os.environ["SMTP_SERVER"]
+    smtp_port = int(os.environ.get("SMTP_PORT", 587))
+    username = os.environ["SMTP_USERNAME"]
+    password = os.environ["SMTP_PASSWORD"]
+
+    message = EmailMessage()
+    message["From"] = username
+    message["To"] = recipient
+    message["Subject"] = subject
+    message.set_content(body)
+
+    with smtplib.SMTP(smtp_server, smtp_port) as server:
+        server.starttls()
+        server.login(username, password)
+        server.send_message(message)

--- a/src/notify.py
+++ b/src/notify.py
@@ -1,0 +1,5 @@
+from email_utils import send_email
+
+
+if __name__ == "__main__":
+    send_email("jakealanlawrence@gmail.com")

--- a/tests/test_email_utils.py
+++ b/tests/test_email_utils.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch
+
+from email_utils import send_email
+
+
+def test_send_email(monkeypatch):
+    monkeypatch.setenv("SMTP_SERVER", "smtp.example.com")
+    monkeypatch.setenv("SMTP_PORT", "587")
+    monkeypatch.setenv("SMTP_USERNAME", "user@example.com")
+    monkeypatch.setenv("SMTP_PASSWORD", "password")
+
+    with patch("smtplib.SMTP") as mock_smtp:
+        send_email("recipient@example.com", subject="Hi", body="Hello")
+
+        mock_smtp.assert_called_with("smtp.example.com", 587)
+        server = mock_smtp.return_value.__enter__.return_value
+        server.starttls.assert_called_once()
+        server.login.assert_called_once_with("user@example.com", "password")
+        server.send_message.assert_called_once()


### PR DESCRIPTION
## Summary
- create a `send_email` helper for SMTP-based mail
- add `notify` script that emails jakealanlawrence@gmail.com
- test email sending logic with mocked SMTP

## Testing
- `ruff check src tests`
- `pytest -q`
